### PR TITLE
supports adding fields not defined in schema

### DIFF
--- a/api/entries.js
+++ b/api/entries.js
@@ -1,20 +1,33 @@
 var EntryModel = require('../models/entries');
+var _ = require('underscore');
 
+// save entry helper
 var saveEntry = function(data) {
     EntryModel.find({playerID: data.playerID, timestamp: data.timestamp}, function(err, result){
         if (err) {
             console.log(err);
         } else {
             if (!result.length){
-                var entry = new EntryModel({
+
+                var tempObj = {
                     area: data.area,
                     playerID: data.playerID,
                     timestamp: data.timestamp,
                     posX: data.posX,
                     posY: data.posY,
-                    cameraX: data.cameraX,
-                    cameraY: data.cameraY
+                }
+                
+                // gets the rest of the key
+                var restKeys = _.chain(data)
+                                .omit(['area', 'playerID', 'timestamp', 'posX', 'posY'])
+                                .keys()
+                                .value();
+
+                restKeys.forEach(function(key) {
+                    tempObj[key] = data[key]
                 });
+                console.log(tempObj);
+                var entry = new EntryModel(tempObj);
 
                 entry.save(function(err) {
                     if (err) {

--- a/models/entries.js
+++ b/models/entries.js
@@ -4,7 +4,8 @@ var Schema = mongoose.Schema;
 
 var EntrySchema = new Schema({
     area: {
-        type: String
+        type: String,
+        required: true
     },
     playerID: {
         type: Number,
@@ -15,17 +16,13 @@ var EntrySchema = new Schema({
         required: true
     },
     posX: {
-        type: Number
+        type: Number,
+        required: true
     },
     posY: {
-        type: Number
-    },
-    cameraX: {
-        type: Number
-    },
-    cameraY: {
-        type: Number
+        type: Number,
+        required: true
     }
-});
+}, { strict: false });
 
 module.exports = mongoose.model('Entry', EntrySchema);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "body-parser": "^1.11.0",
     "connect": "^3.3.4",
     "express": "~4.9.x",
-    "mongoose": "^4.x"
+    "mongoose": "^4.x",
+    "underscore": "^1.8.2"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
['area', 'playerID', 'timestamp', 'posX', 'posY'] are the 5 required fields

we support adding all other fields besides those in our POST to api/entries
